### PR TITLE
allow Strings as well as charlists

### DIFF
--- a/lib/sshex.ex
+++ b/lib/sshex.ex
@@ -26,10 +26,14 @@ defmodule SSHEx do
     Returns `{:ok, connection}`, or `{:error, reason}`.
   """
   def connect(opts) do
-    opts = opts |> H.defaults(port: 22,
-                              negotiation_timeout: 5000,
-                              silently_accept_hosts: true,
-                              ssh_module: :ssh)
+    opts = 
+      opts 
+      |> H.convert_values 
+      |> H.defaults(port: 22,
+                    negotiation_timeout: 5000,
+                    silently_accept_hosts: true,
+                    ssh_module: :ssh)
+
     own_keys = [:ip, :port, :negotiation_timeout, :ssh_module]
 
     ssh_opts = opts |> Enum.filter(fn({k,_})-> not (k in own_keys) end)
@@ -58,10 +62,13 @@ defmodule SSHEx do
     ```
   """
   def run(conn, cmd, opts \\ []) do
-    opts = opts |> H.defaults(connection_module: :ssh_connection,
-                              channel_timeout: 5000,
-                              exec_timeout: 5000)
-
+    opts = 
+      opts 
+      |> H.convert_values 
+      |> H.defaults(connection_module: :ssh_connection,
+                    channel_timeout: 5000,
+                    exec_timeout: 5000)
+    cmd = H.convert_value(cmd)
     case open_channel_and_exec(conn, cmd, opts) do
       {:error, r} -> {:error, r}
       chn -> get_response(conn, chn, opts[:exec_timeout], "", "", nil, false, opts)
@@ -131,10 +138,14 @@ defmodule SSHEx do
     ```
   """
   def stream(conn, cmd, opts \\ []) do
-    opts = opts |> H.defaults(connection_module: :ssh_connection,
-                              channel_timeout: 5000,
-                              exec_timeout: 5000)
+    opts = 
+      opts 
+      |> H.convert_values
+      |> H.defaults(connection_module: :ssh_connection,
+                    channel_timeout: 5000,
+                    exec_timeout: 5000)
 
+    cmd = H.convert_value(cmd)
     start_fun = fn-> open_channel_and_exec(conn,cmd,opts) end
 
     next_fun = fn(input)->

--- a/lib/sshex/helpers.ex
+++ b/lib/sshex/helpers.ex
@@ -67,4 +67,14 @@ defmodule SSHEx.Helpers do
     defs |> Keyword.merge(args)
   end
 
+  def convert_values(args) do
+    Enum.map(args, fn {k, v} -> {k, convert_value(v)} end)
+  end
+
+  def convert_value(v) when is_binary(v) do
+    String.to_charlist(v)
+  end
+
+  def convert_value(v), do: v
+
 end

--- a/test/sshex_test.exs
+++ b/test/sshex_test.exs
@@ -20,6 +20,16 @@ defmodule SSHExTest do
     assert SSHEx.cmd!(:mocked, 'somecommand', connection_module: AllOKMock) == mocked_data
   end
 
+  test "String `cmd!`" do
+    # send mocked response sequence to the mailbox
+    mocked_data = "output"
+    status = 123 # any would do
+    send_regular_sequence mocked_data, status
+
+    # actually test it
+    assert SSHEx.cmd!(:mocked, "somecommand", connection_module: AllOKMock) == mocked_data
+  end
+
   test "Plain `run`" do
     # send mocked response sequence to the mailbox
     mocked_data = "output"
@@ -28,6 +38,15 @@ defmodule SSHExTest do
 
     assert SSHEx.run(:mocked, 'somecommand', connection_module: AllOKMock) == {:ok, mocked_data, status}
   end
+
+  test "String `run`" do
+    # send mocked response sequence to the mailbox
+    mocked_data = "output"
+    status = 123 # any would do
+    send_regular_sequence mocked_data, status
+
+    assert SSHEx.run(:mocked, "somecommand", connection_module: AllOKMock) == {:ok, mocked_data, status}
+  end  
 
   test "Stream long response" do
     lines = ["some", "long", "output", "sequence"]


### PR DESCRIPTION
I found myself writing a lot of `String.to_charlist` when using this, and I thought it would be convenient if the library took care of the conversion when necessary.